### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/music-mood-matcher-demo/security/code-scanning/1](https://github.com/djleamen/music-mood-matcher-demo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out the code), we will set `contents: read`. This ensures that the workflow has the minimum required permissions and avoids granting unnecessary write access.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
